### PR TITLE
Security fix for Prototype Pollution

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,9 @@ function objectDeepKey<DeepObject extends Record<string, any> = {}>(
   object: DeepObject,
   key: string
 ) {
+  if (object === Object.prototype)
+    throw `Restricted modifying Object Prototype`;
+
   const get = () => {
     if (!has()) {
       throw `Property at path ${key} was not found`;
@@ -35,7 +38,7 @@ function objectDeepKey<DeepObject extends Record<string, any> = {}>(
     if (!has()) {
       throw `Property at path ${key} was not found`;
     }
-
+    
     const path = parsePath(key);
     let current = object;
 


### PR DESCRIPTION
### :bar_chart: Metadata *

`object-deep-key` is vulnerable to `Prototype Pollution`.

#### Bounty URL: https://www.huntr.dev/bounties/1-npm-object-deep-key

### :gear: Description *

Prototype Pollution refers to the ability to inject properties into existing JavaScript language construct prototypes, such as objects.
JavaScript allows all Object attributes to be altered, including their magical attributes such as `__proto__`, `constructor` and `prototype`. An attacker manipulates these attributes to overwrite, or pollute, a JavaScript application object prototype of the base object by injecting other values. Properties on the Object.prototype are then inherited by all the JavaScript objects through the prototype chain.

### :computer: Technical Description *

Fix implemented by not allowing to modify object prototype.

### :bug: Proof of Concept (PoC) *

1. Create the following PoC file:
```JavaScript
// poc.js
const objDeepKey = require('object-deep-key').default

console.log(`Before: ${{}.toString}`)
objDeepKey(constructor.prototype, 'toString').set('function prototype polluted')
console.log(`After: ${{}.toString}`)
```
2. Execute the following commands in terminal:
```bash
npm i object-deep-key # Install affected module
node poc.js #  Run the PoC
```
3. Check the Output:
```
Before: function toString() { [native code] }
After: function prototype polluted
```

### :fire: Proof of Fix (PoF) *

![image](https://user-images.githubusercontent.com/43996156/104121731-88b0f480-5366-11eb-8106-94757b2d7be0.png)

### +1 User Acceptance Testing (UAT)

* I've executed unit tests.
* After fix the functionality is unaffected.
